### PR TITLE
replace video URLs with instructions on how to find them

### DIFF
--- a/docs/teaching_materials/sept_11/sept_11_session.qmd
+++ b/docs/teaching_materials/sept_11/sept_11_session.qmd
@@ -29,7 +29,7 @@ The purpose of this class is to cover what RAP is and why RAP is important. The 
 
 ## Recording of the training 
 
-![Training 1 recording](https://file.notion.so/f/f/3e3fd5c7-4d8f-4e03-80ee-afa84877c8f3/1ab4d22d-bebb-4a16-a0f0-c342f3068c12/Reminder__Invitation_to_the_session_of_the_ESCAP_Big_Data_Project_Web_Scraping_Prices_for_CPI_Training_Programme__Developing_a_Reproducible_Analytical_Pipeline-20240911_090309-Meeting_Recording.mp4?table=block&id=c42236c1-ed2f-49c5-b8b9-49cba6a064ff&spaceId=3e3fd5c7-4d8f-4e03-80ee-afa84877c8f3&expirationTimestamp=1734904800000&signature=_AJJKq4YNm6q3zeKxUg_Lb9s1DHge77aVsGa4IEauoY&downloadName=Reminder_+Invitation+to+the+session+of+the+ESCAP+Big+Data+Project+Web+Scraping+Prices+for+CPI+Training+Programme_+Developing+a+Reproducible+Analytical+Pipeline-20240911_090309-Meeting+Recording.mp4)
+A recording of the session is available [on the Notion site](https://xtophe.notion.site/Web-Scraping-for-CPI-Training-c36b27c2ea6b4f02ad760069afaf6fb5). Expand the "Online sessions" section at the top of the page, and then further expand the "Session 12 ..." sub-section to find the video.
 
 ## Slides used in the training
 

--- a/docs/teaching_materials/sept_18/sept_18_session.qmd
+++ b/docs/teaching_materials/sept_18/sept_18_session.qmd
@@ -18,7 +18,7 @@ Unlike the first class that aimed to introduce RAP and why it was relevant, the 
 
 ## Recording of the training
 
-![Training 2 recording](https://file.notion.so/f/f/3e3fd5c7-4d8f-4e03-80ee-afa84877c8f3/0c66f8e0-4d5b-40cf-b2cc-86c283fcf441/Invitation_to_the_session_of_the_ESCAP_Big_Data_Project_Web_Scraping_Prices_for_CPI_Training_Programme__Developing_a_Reproducible_Analytical_Pipeline_-PArt2-20240918_085730-Meeting_Recording.mp4?table=block&id=105dc6a9-96cf-805c-b4bf-d3d52e58d667&spaceId=3e3fd5c7-4d8f-4e03-80ee-afa84877c8f3&expirationTimestamp=1734904800000&signature=KKyUycNxLd9Z9PyWHy9G9nT3ZYDDmpICyPggOyml3jI&downloadName=Invitation+to+the+session+of+the+ESCAP+Big+Data+Project+Web+Scraping+Prices+for+CPI+Training+Programme_+Developing+a+Reproducible+Analytical+Pipeline+-PArt2-20240918_085730-Meeting+Recording.mp4)
+A recording of the session is available [on the Notion site](https://xtophe.notion.site/Web-Scraping-for-CPI-Training-c36b27c2ea6b4f02ad760069afaf6fb5). Scroll down to "Day 2" of the "In-person course" section and expand the "Video Recording" sub-section.
 
 ## Presentation for the session
 


### PR DESCRIPTION
As the URLs for the videos had a built in expiration timestamp, replaced them with instructions on how to find the videos